### PR TITLE
Add ability to list all deps

### DIFF
--- a/bindep/depends.py
+++ b/bindep/depends.py
@@ -194,6 +194,19 @@ class Depends(object):
                 result.append(rule)
         return result
 
+    def list_packages_csv(self, rules):
+        """Print a comma separated list of all packages that are required on
+        this platform according to the passed in rules. This is useful if we
+        want to build RPMs based on the deps listed in bindeps.txt
+
+        :param rules: A list of rules, as returned by active_rules.
+        :return: Nothing, just print a comma separated list
+        """
+        packages_csv = ''
+        for rule in rules:
+            packages_csv += rule[0] + ','
+        logging.info(packages_csv[:-1])
+
     def check_rules(self, rules):
         """Evaluate rules against the local environment.
 

--- a/bindep/main.py
+++ b/bindep/main.py
@@ -41,6 +41,9 @@ def main(depends=None):
     parser.add_option(
         "--profiles", action="store_true",
         help="List the platform and configuration profiles.")
+    parser.add_option(
+        "-l", "--list_all", action="store_true", dest="list_all",
+        help="List all dependencies for this platform and profile.")
     opts, args = parser.parse_args()
     if depends is None:
         depends = bindep.depends.get_depends(opts.filename)
@@ -61,6 +64,9 @@ def main(depends=None):
             profiles = ["default"]
         profiles = profiles + depends.platform_profiles()
         rules = depends.active_rules(profiles)
+        if args.list_all:
+            depends.list_packages_csv(rules)
+            return 0
         errors = depends.check_rules(rules)
         for error in errors:
             if error[0] == 'missing':


### PR DESCRIPTION
These changes add a new feature which allows users
to list all dependencies for their platform in csv
format. This is really useful if people want to take
the deps found in bindeps.text and use them in an
RPM spec file to build an RPM.